### PR TITLE
Pass cli arguments to "run_testserver" command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ name: Test
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: '0 8 * * *'
 

--- a/README.creole
+++ b/README.creole
@@ -72,6 +72,8 @@ e.g.:
 }}}
 The web page is available via: {{{http://127.0.0.1:8000/}}}
 
+You can also pass a other port number or {{{ipaddr:port}}} combination. See: {{{./devshell.py run_testserver --help}}}
+
 Call manage commands from test project, e.g.:
 {{{
 ~/PyInventory$ ./devshell.py manage --help

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,8 @@ e.g.:
 
 The web page is available via: ``http://127.0.0.1:8000/``
 
+You can also pass a other port number or ``ipaddr:port`` combination. See: ``./devshell.py run_testserver --help``
+
 Call manage commands from test project, e.g.:
 
 ::
@@ -387,4 +389,4 @@ donation
 
 ------------
 
-``Note: this file is generated from README.creole 2021-05-11 17:00:54 with "python-creole"``
+``Note: this file is generated from README.creole 2021-08-04 09:01:51 with "python-creole"``

--- a/src/inventory/management/commands/run_testserver.py
+++ b/src/inventory/management/commands/run_testserver.py
@@ -1,15 +1,16 @@
 import os
 
-from django.core.management import BaseCommand, call_command
+from django.core.management import call_command
+from django.core.management.commands.runserver import Command as RunServerCommand
 
 
-class Command(BaseCommand):
+class Command(RunServerCommand):
     help = "Run Django dev. Server"
 
     def verbose_call(self, command, **kwargs):
         self.stdout.write("\n")
         self.stdout.write("_" * 79)
-        self.stdout.write(self.style.NOTICE(f" *** call '{command}' command:"))
+        self.stdout.write(self.style.NOTICE(f" *** call '{command}' command with {kwargs}:"))
         self.stdout.write("\n")
         call_command(command, **kwargs)
 
@@ -23,4 +24,4 @@ class Command(BaseCommand):
             self.verbose_call("migrate", run_syncdb=True, interactive=False, verbosity=1)
             self.verbose_call("showmigrations", verbosity=1)
 
-        self.verbose_call("runserver", use_threading=True, use_reloader=True, verbosity=2)
+        self.verbose_call("runserver", **options)

--- a/src/inventory_project/manage.py
+++ b/src/inventory_project/manage.py
@@ -33,7 +33,7 @@ def start_test_server():
     """
     Entrypoint for "[tool.poetry.scripts]" script started by devshell command.
     """
-    main(argv=[__file__, "run_testserver"])
+    main(argv=[__file__, "run_testserver"] + sys.argv[1:])
 
 
 if __name__ == '__main__':

--- a/src/inventory_project/tests/test_run_testserver.py
+++ b/src/inventory_project/tests/test_run_testserver.py
@@ -1,0 +1,37 @@
+import subprocess
+import sys
+from pathlib import Path
+from unittest import TestCase
+
+from dev_shell.utils.assertion import assert_is_file
+
+import inventory
+
+
+BASE_PATH = Path(inventory.__file__).parent.parent.parent
+
+
+def call_run_testserver(*args):
+    dev_shell_py = BASE_PATH / 'devshell.py'
+    assert_is_file(dev_shell_py)
+    output = subprocess.check_output(
+        [sys.executable, str(dev_shell_py), 'run_testserver'] + list(args),
+        stderr=subprocess.STDOUT,
+        text=True
+    )
+    return output
+
+
+class RunTestServerTestCase(TestCase):
+    def test_run_testserver(self):
+        output = call_run_testserver('--help')
+        assert 'usage: manage.py run_testserver' in output
+        assert 'Run Django dev. Server' in output
+        assert 'Optional port number, or ipaddr:port' in output
+
+    def test_pass_wrong_addrport(self):
+        output = call_run_testserver('not-ip:no-port')
+        assert "call 'runserver' command with" in output
+        assert (
+            'CommandError: "not-ip:no-port" is not a valid port number or address:port pair.'
+        ) in output


### PR DESCRIPTION
So it's possible to start the Django dev server on a other attr/port than `127.0.0.1:8000`

e.g.:

```
./devshell.py run_testserver 192.168.0.1:8080
```