### PR TITLE
Fix CKEditor

### DIFF
--- a/src/inventory/static/inventory.css
+++ b/src/inventory/static/inventory.css
@@ -8,3 +8,16 @@
    	line-height: 0.3em;
     color: #333;
 }
+.django-ckeditor-widget {
+    width: 75%;
+}
+@media (max-width: 1100px) {
+    .django-ckeditor-widget {
+        width: 100%;
+    }
+}
+@media (max-width: 767px) {
+    .django-ckeditor-widget {
+        width: 99%;
+    }
+}

--- a/src/inventory_project/settings/base.py
+++ b/src/inventory_project/settings/base.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path as __Path
 
+from ckeditor.configs import DEFAULT_CONFIG
 from django.utils.translation import gettext_lazy as _
 
 
@@ -168,17 +169,18 @@ DBBACKUP_STORAGE_OPTIONS = {'location': str(__Path(BASE_PATH, 'backups'))}
 
 CKEDITOR_BASEPATH = STATIC_URL + 'ckeditor/ckeditor/'
 CKEDITOR_FILENAME_GENERATOR = 'inventory.ckeditor_upload.get_filename'
-CKEDITOR_DEFAULT_CONFIG = {
-    'skin': 'moono-lisa',
+CKEDITOR_DEFAULT_CONFIG = DEFAULT_CONFIG
+CKEDITOR_DEFAULT_CONFIG.update({
     'removeButtons': 'Language,Cut,Copy,Paste,Undo,Redo,Anchor',
 
     # plugins are here: .../site-packages/ckeditor/static/ckeditor/ckeditor/plugins
     # and here: https://github.com/ckeditor/ckeditor4/tree/major/plugins
     # See also: .../site-packages/ckeditor/static/ckeditor/ckeditor/build-config.js
     'removePlugins': (
-        # Generated with .../dev-scripts/ckeditor_info.py
+        # Generated with devshell command:
+        # (inventory) ckeditor_info
         'a11yhelp',
-        'about',
+        # 'about',
         'adobeair',
         'ajax',
         'autoembed',
@@ -207,6 +209,7 @@ CKEDITOR_DEFAULT_CONFIG = {
         'embedsemantic',
         'enterkey',
         # 'entities',
+        'exportpdf',
         # 'filebrowser',
         # 'filetools',
         'find',
@@ -253,7 +256,7 @@ CKEDITOR_DEFAULT_CONFIG = {
         # 'showblocks',
         # 'showborders',
         'smiley',
-        'sourcearea',
+        # 'sourcearea',
         'sourcedialog',
         'specialchar',
         'stylescombo',
@@ -274,12 +277,33 @@ CKEDITOR_DEFAULT_CONFIG = {
         # 'wysiwygarea',
         'xml',
     ),
-    'toolbar': 'full',
+    'toolbar_PyInventoryToolbarConfig': [
+        {'name': 'basicstyles', 'items': [
+            'Bold', 'Italic', 'Underline', 'Strike',
+            '-',
+            'RemoveFormat'
+        ]},
+        {'name': 'paragraph', 'items': [
+            'NumberedList', 'BulletedList',
+            '-',
+            'Outdent', 'Indent',
+            '-',
+            'Blockquote',
+            '-',
+            'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock',
+        ]},
+        {'name': 'links', 'items': ['Link', 'Unlink', 'Anchor']},
+        {'name': 'insert', 'items': ['Image', 'Table', 'HorizontalRule']},
+        '/',
+        {'name': 'styles', 'items': ['Styles', 'Format', 'Font', 'FontSize']},
+        {'name': 'colors', 'items': ['TextColor', 'BGColor']},
+        {'name': 'tools', 'items': ['Maximize', 'ShowBlocks', 'Source']},
+        {'name': 'about', 'items': ['About']},
+    ],
+    'toolbar': 'PyInventoryToolbarConfig',
     'height': '25em',
     'width': '100%',
-    'filebrowserWindowWidth': 940,
-    'filebrowserWindowHeight': 725,
-}
+})
 CKEDITOR_CONFIGS = {
     'ItemModel.description': CKEDITOR_DEFAULT_CONFIG,
     'LocationModel.description': CKEDITOR_DEFAULT_CONFIG


### PR DESCRIPTION
v0.10.1 toolbar looks like this:

![grafik](https://user-images.githubusercontent.com/71315/136667803-954d66d1-db62-4ee9-84c3-38f692718958.png)

Toolbar with this PR:

![grafik](https://user-images.githubusercontent.com/71315/136667814-0434b53f-2a98-4d66-8ceb-71d06eda3417.png)


Useless icons was removed. (Note: PDF generation doesn't work)
Add "Source code" icon (Can help to fix bugs) and add the "About" icon.