### PR TITLE
FIXME: Remove '_reorder_' from ItemModelAdmin.list_display

### DIFF
--- a/src/inventory/admin/item.py
+++ b/src/inventory/admin/item.py
@@ -155,5 +155,15 @@ class ItemModelAdmin(TagulousModelAdminFix, ImportExportMixin, SortableAdminMixi
     readonly_fields = ('id', 'create_dt', 'update_dt', 'user', 'related_items')
     inlines = (ItemImageModelInline, ItemFileModelInline, ItemLinkModelInline)
 
+    def get_list_display(self, request):
+        list_display = list(super().get_list_display(request))
+
+        # FIXME: SortableAdminMixin.get_list_display() adds this, we didn't need here:
+        # See: https://github.com/jrief/django-admin-sortable2/issues/363
+        if '_reorder_' in list_display:
+            list_display.remove('_reorder_')
+
+        return list_display
+
 
 tagulous.admin.enhance(ItemModel, ItemModelAdmin)

--- a/src/inventory_project/tests/test_admin_item_auto_group_items_1.snapshot.html
+++ b/src/inventory_project/tests/test_admin_item_auto_group_items_1.snapshot.html
@@ -81,21 +81,6 @@
           <div class="clear">
           </div>
          </th>
-         <th class="sortable column-_reorder_ sorted ascending" scope="col">
-          <div class="sortoptions">
-           <a class="sortremove" href="?o=" title="Remove from sorting">
-           </a>
-           <a class="toggle ascending" href="?o=-1" title="Toggle sorting">
-           </a>
-          </div>
-          <div class="text">
-           <a href="?o=-1">
-            Path str
-           </a>
-          </div>
-          <div class="clear">
-          </div>
-         </th>
          <th class="column-_tagulous_display_producer" scope="col">
           <div class="text">
            <span>
@@ -105,9 +90,15 @@
           <div class="clear">
           </div>
          </th>
-         <th class="sortable column-item" scope="col">
+         <th class="sortable column-item sorted ascending" scope="col">
+          <div class="sortoptions">
+           <a class="sortremove" href="?o=" title="Remove from sorting">
+           </a>
+           <a class="toggle ascending" href="?o=-2" title="Toggle sorting">
+           </a>
+          </div>
           <div class="text">
-           <a href="?o=3.1">
+           <a href="?o=-2">
             Item
            </a>
           </div>
@@ -125,7 +116,7 @@
          </th>
          <th class="sortable column-location" scope="col">
           <div class="text">
-           <a href="?o=5.1">
+           <a href="?o=4.2">
             Location
            </a>
           </div>
@@ -134,7 +125,7 @@
          </th>
          <th class="sortable column-received_date" scope="col">
           <div class="text">
-           <a href="?o=6.1">
+           <a href="?o=5.2">
             Received date
            </a>
           </div>
@@ -143,7 +134,7 @@
          </th>
          <th class="sortable column-update_dt" scope="col">
           <div class="text">
-           <a href="?o=7.1">
+           <a href="?o=6.2">
             Last update
            </a>
           </div>
@@ -156,10 +147,6 @@
         <tr>
          <td class="action-checkbox">
           <input class="action-select" name="_selected_action" type="checkbox" value="00000000-0001-0000-0000-000000000000"/>
-         </td>
-         <td class="field-_reorder_">
-          <div class="drag handle" order="mainitem1" pk="00000000-0001-0000-0000-000000000000">
-          </div>
          </td>
          <th class="field-_tagulous_display_producer">
           <a href="/admin/inventory/itemmodel/00000000-0001-0000-0000-000000000000/change/">
@@ -187,10 +174,6 @@
         <tr>
          <td class="action-checkbox">
           <input class="action-select" name="_selected_action" type="checkbox" value="00000000-0001-0001-0000-000000000000"/>
-         </td>
-         <td class="field-_reorder_">
-          <div class="drag handle" order="mainitem1 0 subitem11" pk="00000000-0001-0001-0000-000000000000">
-          </div>
          </td>
          <th class="field-_tagulous_display_producer">
           <a href="/admin/inventory/itemmodel/00000000-0001-0001-0000-000000000000/change/">
@@ -220,10 +203,6 @@
          <td class="action-checkbox">
           <input class="action-select" name="_selected_action" type="checkbox" value="00000000-0001-0002-0000-000000000000"/>
          </td>
-         <td class="field-_reorder_">
-          <div class="drag handle" order="mainitem1 0 subitem12" pk="00000000-0001-0002-0000-000000000000">
-          </div>
-         </td>
          <th class="field-_tagulous_display_producer">
           <a href="/admin/inventory/itemmodel/00000000-0001-0002-0000-000000000000/change/">
           </a>
@@ -252,10 +231,6 @@
          <td class="action-checkbox">
           <input class="action-select" name="_selected_action" type="checkbox" value="00000000-0002-0000-0000-000000000000"/>
          </td>
-         <td class="field-_reorder_">
-          <div class="drag handle" order="mainitem2" pk="00000000-0002-0000-0000-000000000000">
-          </div>
-         </td>
          <th class="field-_tagulous_display_producer">
           <a href="/admin/inventory/itemmodel/00000000-0002-0000-0000-000000000000/change/">
           </a>
@@ -282,10 +257,6 @@
         <tr>
          <td class="action-checkbox">
           <input class="action-select" name="_selected_action" type="checkbox" value="00000000-0002-0001-0000-000000000000"/>
-         </td>
-         <td class="field-_reorder_">
-          <div class="drag handle" order="mainitem2 0 subitem21" pk="00000000-0002-0001-0000-000000000000">
-          </div>
          </td>
          <th class="field-_tagulous_display_producer">
           <a href="/admin/inventory/itemmodel/00000000-0002-0001-0000-000000000000/change/">
@@ -314,10 +285,6 @@
         <tr>
          <td class="action-checkbox">
           <input class="action-select" name="_selected_action" type="checkbox" value="00000000-0002-0002-0000-000000000000"/>
-         </td>
-         <td class="field-_reorder_">
-          <div class="drag handle" order="mainitem2 0 subitem22" pk="00000000-0002-0002-0000-000000000000">
-          </div>
          </td>
          <th class="field-_tagulous_display_producer">
           <a href="/admin/inventory/itemmodel/00000000-0002-0002-0000-000000000000/change/">


### PR DESCRIPTION
FIXME: SortableAdminMixin.get_list_display() adds this, but we didn't need it on the main ModelAdmin
class. See: https://github.com/jrief/django-admin-sortable2/issues/363