### PR TITLE
fix for https://github.com/jrief/django-admin-sortable2/issues/363

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ To make a new release, do this:
 
 [comment]: <> (✂✂✂ auto generated history start ✂✂✂)
 
+* [**dev**](https://github.com/jedie/PyInventory/compare/v0.21.4...main)
+  * 2025-09-21 - fix for django-admin-sortable2/issues/363
 * [v0.21.4](https://github.com/jedie/PyInventory/compare/v0.21.3...v0.21.4)
   * 2025-09-21 - Because of PyPi download errors: release as v0.21.4
 * [v0.21.3](https://github.com/jedie/PyInventory/compare/v0.21.2...v0.21.3)
@@ -183,12 +185,12 @@ To make a new release, do this:
 * [v0.21.2](https://github.com/jedie/PyInventory/compare/v0.21.1...v0.21.2)
   * 2025-09-09 - Update project, e.g.: Darker -> Ruff and fix tests
   * 2025-05-01 - Fix local dev server: Don't enforce https
-* [v0.21.1](https://github.com/jedie/PyInventory/compare/v0.21.0...v0.21.1)
-  * 2025-05-01 - Replace setuptools with hatchling
-  * 2025-04-30 - Update requirements and some small code parts
 
 <details><summary>Expand older history entries ...</summary>
 
+* [v0.21.1](https://github.com/jedie/PyInventory/compare/v0.21.0...v0.21.1)
+  * 2025-05-01 - Replace setuptools with hatchling
+  * 2025-04-30 - Update requirements and some small code parts
 * [v0.21.0](https://github.com/jedie/PyInventory/compare/v0.20.1...v0.21.0)
   * 2025-03-23 - Bugfix publish: setuptools missing
   * 2025-03-23 - Migrate "pip-tools" -> "uv" and remove tox

--- a/inventory/admin/item.py
+++ b/inventory/admin/item.py
@@ -1,7 +1,7 @@
 import logging
 
 import tagulous
-from adminsortable2.admin import SortableAdminMixin, SortableInlineAdminMixin
+from adminsortable2.admin import SortableAdminBase, SortableInlineAdminMixin
 from django.conf import settings
 from django.contrib import admin
 from django.template.loader import render_to_string
@@ -46,7 +46,7 @@ class ItemModelResource(ModelResource):
 
 
 @admin.register(ItemModel)
-class ItemModelAdmin(TagulousModelAdminFix, ImportExportMixin, SortableAdminMixin, BaseUserAdmin):
+class ItemModelAdmin(TagulousModelAdminFix, ImportExportMixin, SortableAdminBase, BaseUserAdmin):
     @admin.display(description=_('Related items'))
     def related_items(self, obj):
         if obj.pk is None:
@@ -160,16 +160,6 @@ class ItemModelAdmin(TagulousModelAdminFix, ImportExportMixin, SortableAdminMixi
     autocomplete_fields = ('parent', 'location')
     readonly_fields = ('id', 'create_dt', 'update_dt', 'user', 'related_items')
     inlines = (ItemImageModelInline, ItemFileModelInline, ItemLinkModelInline)
-
-    def get_list_display(self, request):
-        list_display = list(super().get_list_display(request))
-
-        # FIXME: SortableAdminMixin.get_list_display() adds this, we didn't need here:
-        # See: https://github.com/jrief/django-admin-sortable2/issues/363
-        if '_reorder_' in list_display:
-            list_display.remove('_reorder_')
-
-        return list_display
 
 
 tagulous.admin.enhance(ItemModel, ItemModelAdmin)

--- a/inventory_project/tests/test_admin_item_auto_group_items_1.snapshot.html
+++ b/inventory_project/tests/test_admin_item_auto_group_items_1.snapshot.html
@@ -5,6 +5,16 @@
  <div id="content-main">
   <ul class="object-tools">
    <li>
+    <a class="import_link" href="/admin/inventory/itemmodel/import/">
+     Import
+    </a>
+   </li>
+   <li>
+    <a class="export_link" href="/admin/inventory/itemmodel/export/?">
+     Export
+    </a>
+   </li>
+   <li>
     <a class="recoverlink" href="/admin/inventory/itemmodel/recover/">
      Recover deleted Items
     </a>
@@ -52,8 +62,6 @@
        </select>
       </label>
       <input class="select-across" name="select_across" type="hidden" value="0"/>
-      <input id="changelist-form-step" name="step" type="number" value="1"/>
-      <input id="changelist-form-page" name="page" type="number"/>
       <button class="button" name="index" title="Run the selected action" type="submit" value="0">
        Go
       </button>


### PR DESCRIPTION
replace "SortableAdminMixin" with "SortableAdminBase", because `ItemModel` is not sortable! Only some inlines!